### PR TITLE
add user coupon interest source tracker to position

### DIFF
--- a/ledger/types/balances_misc.go
+++ b/ledger/types/balances_misc.go
@@ -2,9 +2,11 @@ package types
 
 import (
 	"encoding/json"
-	"github.com/dora-network/dora-service-utils/errors"
 	"regexp"
+	"strconv"
 	"strings"
+
+	"github.com/dora-network/dora-service-utils/errors"
 )
 
 // Validate that Balances does not contain any empty asset IDs
@@ -132,6 +134,12 @@ func (b *Balances) String() string {
 // ValidAssetID checks that an asset ID contains only alphanumeric characters and underscores,
 // as well as at most one hyphen somewhere in the middle, and is non-empty.
 func ValidAssetID(id string) error {
+	couponPrefix := "Coupon_"
+	if strings.HasPrefix(id, couponPrefix) {
+		// InterestSources entries do not start with coupon asset, they end with it.
+		// Individual asset IDs must not start with this prefix either, to prevent confusion.
+		return errors.Data("invalid asset ID: %s", id)
+	}
 	re := regexp.MustCompile("[^A-Za-z0-9_-]")
 	trimmed := re.ReplaceAllLiteralString(id, "")
 	if id == "" ||
@@ -140,6 +148,25 @@ func ValidAssetID(id string) error {
 		strings.HasSuffix(id, "-") ||
 		strings.Count(id, "-") > 1 {
 		return errors.Data("invalid asset ID: %s", id)
+	}
+	split := strings.Split(id, "-")
+	if len(split) == 2 {
+		// ID contained a hyphen. It is either a pool share or an InterestSources entry.
+		s := split[1]
+		if strings.HasPrefix(s, couponPrefix) {
+			// InterestSources entry rules
+			period := strings.TrimPrefix(s, couponPrefix)
+			// Period must be a valid int64 (we don't care what it is, just that it is valid)
+			if _, err := strconv.ParseInt(period, 10, 64); err != nil {
+				return errors.Data("invalid asset ID: %s", id)
+			}
+		} else {
+			// Pool share rules
+			if split[0] == split[1] {
+				// No asset can be paired with itself
+				return errors.Data("invalid asset ID: %s", id)
+			}
+		}
 	}
 	return nil
 }

--- a/ledger/types/module.go
+++ b/ledger/types/module.go
@@ -15,7 +15,6 @@ type Module struct {
 	Virtual *Balances `json:"virtual" redis:"virtual"`
 	// Assets borrowed from supply but not yet repaid
 	Borrowed *Balances `json:"borrowed" redis:"borrowed"`
-
 	// Assets provided to the module by LPs to fund coupon interest.
 	CouponFunds *Balances `json:"coupon_funds" redis:"coupon_funds"`
 
@@ -31,13 +30,32 @@ func (m *Module) MarshalBinary() ([]byte, error) {
 }
 
 func (m *Module) UnmarshalBinary(data []byte) error {
-	return json.Unmarshal(data, m)
+	err := json.Unmarshal(data, m)
+	m.Init() // Init must be called after json unmarshaling
+	return err
 }
 
-// Init sets a position's original field to its current json representation. No-op if already set.
+// Init sets a module's original field to its current json representation. No-op if already set.
 // For a module object to be valid, this must be called after json unmarshaling.
 func (m *Module) Init() {
-	if m != nil && m.original == "" {
+	// Nil balances should not be allowed
+	if m.Balance == nil {
+		m.Balance = EmptyBalances()
+	}
+	if m.Supplied == nil {
+		m.Supplied = EmptyBalances()
+	}
+	if m.Virtual == nil {
+		m.Virtual = EmptyBalances()
+	}
+	if m.Borrowed == nil {
+		m.Borrowed = EmptyBalances()
+	}
+	if m.CouponFunds == nil {
+		m.CouponFunds = EmptyBalances()
+	}
+	// Store original state. No-op if already stored.
+	if m.original == "" {
 		j, err := json.Marshal(m)
 		if err != nil {
 			return
@@ -50,15 +68,10 @@ func (m *Module) Init() {
 
 func InitialModule() *Module {
 	m := &Module{
-		// Balances (can Validate)
-		Balance:     &Balances{Bals: make(map[string]int64)},
-		Supplied:    &Balances{Bals: make(map[string]int64)},
-		Borrowed:    &Balances{Bals: make(map[string]int64)},
-		Virtual:     &Balances{Bals: make(map[string]int64)},
-		CouponFunds: &Balances{Bals: make(map[string]int64)},
 		// Tracking fields
 		Sequence:    0,
 		LastUpdated: 0,
+		// Note: All *Balances fields are set to EmptyBalances by m.Init()
 	}
 	// Track exported fields for IsModified, as well as initial Sequence
 	m.Init()
@@ -82,12 +95,21 @@ func NewModule(
 		LastUpdated: lastUpdated,
 	}
 	// Track exported fields for IsModified, as well as initial Sequence
+	// Also overrides any nil *Balances with EmptyBalances()
 	m.Init()
-	return m, nil
+	return m, m.Validate()
 }
 
 // Validate that Module position does not contain any invalid or negative Balances
 func (m *Module) Validate() error {
+	// Balances.Validate will panic if Balances are nil, so we check first
+	if m.Balance == nil ||
+		m.Supplied == nil ||
+		m.Borrowed == nil ||
+		m.Virtual == nil ||
+		m.CouponFunds == nil {
+		return errors.Data("nil Balances in Module")
+	}
 	if err := m.Balance.Validate(false); err != nil {
 		return errors.Wrap(errors.InvalidInputError, err, "module Balance")
 	}

--- a/ledger/types/position.go
+++ b/ledger/types/position.go
@@ -53,7 +53,7 @@ func (p *Position) MarshalBinary() ([]byte, error) {
 
 func (p *Position) UnmarshalBinary(data []byte) error {
 	err := json.Unmarshal(data, p)
-	p.Init()
+	p.Init() // Init must be called after json unmarshaling
 	return err
 }
 
@@ -79,7 +79,7 @@ func (p *Position) Init() {
 	if p.InterestSources == nil {
 		p.InterestSources = EmptyBalances()
 	}
-	// Store original position. No-op if already stored.
+	// Store original state. No-op if already stored.
 	if p.original == "" {
 		j, err := json.Marshal(p)
 		if err != nil {

--- a/ledger/types/position.go
+++ b/ledger/types/position.go
@@ -9,6 +9,7 @@ import (
 type Position struct {
 	// UserID identifies the owner of the position
 	UserID string `json:"user_id" redis:"user_id"`
+
 	// Assets owned (including bonds and currencies). Negative values indicate borrows.
 	Owned *Balances `json:"owned" redis:"owned"`
 	// Assets locked as potential inputs to user open orders. Subset of positive Owned amounts.
@@ -21,6 +22,16 @@ type Position struct {
 	SSEQ *Balances `json:"sseq" redis:"sseq"`
 	// Assets which have been withheld from a user's Owned balance for technical reasons.
 	Inactive *Balances `json:"inactive" redis:"inactive"`
+	// InterestSources contains supplemental information about Owned "Interest" balances related to coupon payments.
+	// We recycle the Balances struct here, containing map[string]int64, but rather than representing a set of
+	// asset balances like map[AssetID]Amount, each entry in this map represents the amount of AssetID="Interest"
+	// present in Position.Owned which came from a particular bond's specific coupon period.
+	// For example, if InterestSources["Bond_A-Coupon_123456"]=789, then $7.89 of this user's owned interest
+	// came from asset Bond_A's coupon period ending at unix timestamp 123456. Note that the single hyphen
+	// makes the key pass asset ID validation rules, even though it is not any asset's AssetID.
+	// Also note that a negative value (for example, -789) is valid here and would refer to the user owing
+	// interest due to having bought a bond mid-coupon-period.
+	InterestSources *Balances `json:"interest_sources" redis:"interest_sources"`
 
 	// Native stablecoin asset which the user originally deposited and will prefer for withdrawals
 	NativeAsset string `json:"native_asset" redis:"native_asset"`
@@ -41,13 +52,35 @@ func (p *Position) MarshalBinary() ([]byte, error) {
 }
 
 func (p *Position) UnmarshalBinary(data []byte) error {
-	return json.Unmarshal(data, p)
+	err := json.Unmarshal(data, p)
+	p.Init()
+	return err
 }
 
 // Init sets a position's original field to its current json representation. No-op if already set.
 // For a position object to be valid, this must be called after json unmarshaling.
 func (p *Position) Init() {
-	if p != nil && p.original == "" {
+	// Nil balances should not be allowed
+	if p.Owned == nil {
+		p.Owned = EmptyBalances()
+	}
+	if p.Locked == nil {
+		p.Locked = EmptyBalances()
+	}
+	if p.Supplied == nil {
+		p.Supplied = EmptyBalances()
+	}
+	if p.SSEQ == nil {
+		p.SSEQ = EmptyBalances()
+	}
+	if p.Inactive == nil {
+		p.Inactive = EmptyBalances()
+	}
+	if p.InterestSources == nil {
+		p.InterestSources = EmptyBalances()
+	}
+	// Store original position. No-op if already stored.
+	if p.original == "" {
 		j, err := json.Marshal(p)
 		if err != nil {
 			return
@@ -63,16 +96,11 @@ func (p *Position) Init() {
 func InitialPosition(userID string) *Position {
 	p := &Position{
 		UserID: userID,
-		// Balances (can Validate)
-		Owned:    &Balances{Bals: make(map[string]int64)},
-		Locked:   &Balances{Bals: make(map[string]int64)},
-		Supplied: &Balances{Bals: make(map[string]int64)},
-		SSEQ:     &Balances{Bals: make(map[string]int64)},
-		Inactive: &Balances{Bals: make(map[string]int64)},
 		// Tracking fields
 		NativeAsset: "",
 		Sequence:    0,
 		LastUpdated: 0,
+		// Note: All *Balances fields are set to EmptyBalances by p.Init()
 	}
 	// Track exported fields for IsModified, as well as initial Sequence
 	p.Init()
@@ -81,7 +109,7 @@ func InitialPosition(userID string) *Position {
 
 func NewPosition(
 	userID string,
-	owned, locked, supplied, sseq, inactive *Balances,
+	owned, locked, supplied, sseq, inactive, interestSources *Balances,
 	nativeAsset string,
 	lastUpdated int64,
 	sequence uint64,
@@ -89,27 +117,37 @@ func NewPosition(
 	p := &Position{
 		UserID: userID,
 		// Balances (can Validate)
-		Owned:    owned,
-		Locked:   locked,
-		Supplied: supplied,
-		SSEQ:     sseq,
-		Inactive: inactive,
+		Owned:           owned,
+		Locked:          locked,
+		Supplied:        supplied,
+		SSEQ:            sseq,
+		Inactive:        inactive,
+		InterestSources: interestSources,
 		// Tracking fields
 		NativeAsset: nativeAsset,
 		Sequence:    sequence,
 		LastUpdated: lastUpdated,
 	}
 	// Track exported fields for IsModified, as well as initial Sequence
+	// Also overrides any nil *Balances with EmptyBalances()
 	p.Init()
-	return p, nil
+	return p, p.Validate()
 }
 
-// Validate that Position does not contain any invalid Balances
+// Validate that Position does not contain any invalid Balances or empty required fields
 func (p *Position) Validate() error {
 	if p.UserID == "" {
 		return errors.Data("empty user ID in Position")
 	}
-
+	// Balances.Validate will panic if Balances are nil, so we check first
+	if p.Owned == nil ||
+		p.Locked == nil ||
+		p.Supplied == nil ||
+		p.SSEQ == nil ||
+		p.Inactive == nil ||
+		p.InterestSources == nil {
+		return errors.Data("nil Balances in Position")
+	}
 	if err := p.Owned.Validate(true); err != nil {
 		return errors.Wrap(errors.InvalidInputError, err, "position Owned")
 	}
@@ -122,8 +160,14 @@ func (p *Position) Validate() error {
 	if err := p.SSEQ.Validate(true); err != nil {
 		return errors.Wrap(errors.InvalidInputError, err, "position SSEQ")
 	}
+	if err := p.InterestSources.Validate(true); err != nil {
+		return errors.Wrap(errors.InvalidInputError, err, "position Interest Sources")
+	}
 	if err := p.Inactive.Validate(true); err != nil {
 		return errors.Wrap(errors.InvalidInputError, err, "position Inactive")
+	}
+	if err := ValidAssetID(p.NativeAsset); err != nil && p.NativeAsset != "" {
+		return err // notice that error is ignored if NativeAsset is not set
 	}
 	if p.original == "" {
 		return errors.NewInternal("position not initialized")


### PR DESCRIPTION
Also does a safety pass on position, module unmarshalers and constructors. It should be harder to end up with panics or un-initialized data now.