### PR TITLE
chore: migrate pool functions from 0.5 to 1.0

### DIFF
--- a/ledger/types/balance.go
+++ b/ledger/types/balance.go
@@ -79,6 +79,23 @@ func (b *Balance) IsZero() bool {
 	return b.Amount == 0
 }
 
+// Add a balance to this one, returning the result and an error if asset IDs do not match.
+func (b *Balance) Add(bal *Balance) (*Balance, error) {
+	if bal == nil {
+		return b, nil
+	}
+	if !b.Valid() || !bal.Valid() {
+		return nil, errors.New("balance.Add: invalid input")
+	}
+	if b.Asset != bal.Asset {
+		return nil, fmt.Errorf("balance.Add: mismatched assets %s and %s", b.Asset, bal.Asset)
+	}
+	if bal.Amount == 0 {
+		return b, nil
+	}
+	return NewBalance(b.Asset, b.Amount+bal.Amount), nil
+}
+
 // Sub from a balance. Error on negative result, mismatched assets, or invalid assets.
 func (b *Balance) Sub(sub *Balance) (*Balance, error) {
 	if sub == nil {
@@ -87,11 +104,11 @@ func (b *Balance) Sub(sub *Balance) (*Balance, error) {
 	if !b.Valid() || !sub.Valid() {
 		return nil, errors.New("balance.Sub: invalid input")
 	}
-	if sub.Amount == 0 {
-		return b, nil // no-op is safe
-	}
 	if b.Asset != sub.Asset {
 		return nil, fmt.Errorf("balance.Sub: mismatched assets %s and %s", b.Asset, sub.Asset)
+	}
+	if sub.Amount == 0 {
+		return b, nil // no-op is safe
 	}
 	if b.Amount < sub.Amount {
 		return nil, fmt.Errorf("balance.Sub (%s): result would be negative", b.Asset)

--- a/math/math.go
+++ b/math/math.go
@@ -342,3 +342,15 @@ func Min(a, b *big.Int) *big.Int {
 	}
 	return b
 }
+
+func ExecutedPrice(isSell bool, balanceIn, balanceOut uint64) float64 {
+	if balanceIn == 0 || balanceOut == 0 {
+		return 1 // Edge cases return default price
+	}
+	if isSell {
+		// Sell Price = Out / In
+		return float64(balanceOut) / float64(balanceIn)
+	}
+	// Buy Price = In / Out
+	return float64(balanceIn) / float64(balanceOut)
+}


### PR DESCRIPTION
Migrating these functions to 1.0 in order to support the Max Buy back-end calculations for 1.0