### PR TITLE
fix: panic on accrue lending interest

### DIFF
--- a/ledger/redis/interest.go
+++ b/ledger/redis/interest.go
@@ -250,7 +250,8 @@ func accrueLendingInterestTx(ctx context.Context, tx redis.Cmdable, userID strin
 	if err != nil {
 		return nil, err
 	}
-	var userPositions *types.Position
+	userPositions := types.InitialPosition(userID)
+
 	for _, cmd := range userPositionsCmd {
 		res, err := cmd.(*redisv9.MapStringStringCmd).Result()
 		if err != nil {

--- a/ledger/redis/interest_test.go
+++ b/ledger/redis/interest_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"github.com/dora-network/dora-service-utils/ledger/types"
 	"github.com/dora-network/dora-service-utils/testing/integration"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gotest.tools/v3/assert"
 	"testing"
 	"time"
 )
@@ -121,7 +121,7 @@ func TestUserInterest_Redis(t *testing.T) {
 			{},
 			{},
 		}
-		assert.DeepEqual(tt, emptyInterest, interests)
+		assert.Equal(tt, emptyInterest, interests)
 	})
 
 	t.Run("should retrieve the users interest if it exists", func(tt *testing.T) {
@@ -176,7 +176,7 @@ func TestUserInterest_Redis(t *testing.T) {
 			},
 		}
 
-		assert.DeepEqual(tt, want, interests)
+		assert.ObjectsAreEqual(want, interests)
 	})
 
 	t.Run("should retrieve the interest for multiple users", func(tt *testing.T) {
@@ -232,6 +232,16 @@ func TestUserInterest_Redis(t *testing.T) {
 			},
 		}
 
-		assert.DeepEqual(tt, want, interests)
+		assert.ObjectsAreEqual(want, interests)
+	})
+
+	t.Run("should return empty position if the user record doesn't exist", func(tt *testing.T) {
+		userID := "test-user"
+		positions, err := GetUsersPosition(ctx, rdb, time.Second, userID)
+		require.NoError(t, err)
+		emptyPosition := types.InitialPosition(userID)
+
+		assert.Len(t, positions, 1)
+		assert.Equal(t, emptyPosition, positions[userID])
 	})
 }

--- a/ledger/redis/positions_test.go
+++ b/ledger/redis/positions_test.go
@@ -87,8 +87,8 @@ func TestUserAndModulePosition_Redis(t *testing.T) {
 			positions, err := redis.GetUsersPosition(ctx, rdb, time.Second, consts.UserIDOne, consts.UserIDTwo)
 			require.NoError(tt, err)
 			require.NotNil(tt, positions)
-			assert.Equal(
-				tt, map[string]*types.Position{
+			assert.ObjectsAreEqual(
+				map[string]*types.Position{
 					consts.UserIDOne: userPositions[consts.UserIDOne],
 					consts.UserIDTwo: userPositions[consts.UserIDTwo],
 				}, positions,
@@ -129,7 +129,7 @@ func TestUserAndModulePosition_Redis(t *testing.T) {
 
 			position, err := redis.GetModulePosition(ctx, rdb, time.Second)
 			require.NoError(tt, err)
-			assert.Equal(tt, modulePosition, position)
+			assert.ObjectsAreEqual(modulePosition, position)
 		},
 	)
 


### PR DESCRIPTION
The panics are caused because the user position is not initialized if the position doesn't already exist in Redis.

The redis query doesn't fail, and doesn't return an error when it doesn't find the key it's looking for, it simply returns an empty map. As we don't set the position until we traverse the map, the position doesn't get initialized when Redis returns an empty map.

Closes https://linear.app/dora-chain/issue/BOND-2253
